### PR TITLE
Universal server version detection

### DIFF
--- a/classes/RaspStats.php
+++ b/classes/RaspStats.php
@@ -40,7 +40,7 @@ abstract class RaspStats{
     /**
      * Returns an array with server name and server version by using some detection techniques
      * @see apache_get_version()
-     * @return array
+     * @return array|bool
      */
     public static function getWebserverVersion(){
         // Is there a server variable to get the server version ?

--- a/classes/RaspStats.php
+++ b/classes/RaspStats.php
@@ -38,12 +38,31 @@ abstract class RaspStats{
     }
 
     /**
+     * Returns an array with server name and server version by using some detection techniques
      * @see apache_get_version()
-     * @return string
+     * @return array
      */
-    public static function getApacheVersion(){
-        $version = apache_get_version();
-        return ($version ? $version : 'Failed to get Apache version');
+    public static function getWebserverVersion(){
+        // Is there a server variable to get the server version ?
+
+        if(isset($_SERVER['SERVER_SOFTWARE'])){
+            return [
+                'server' => null,
+                'version' => $_SERVER['SERVER_SOFTWARE']
+            ];
+        }
+
+        // PHP provides a function to get Apache's version
+        if(function_exists('apache_get_version')){
+            $version = apache_get_version();
+            return [
+                'server' => 'Apache',
+                'version' => $version ? $version : 'Failed to get Apache version'
+            ];
+        }
+
+        // Maybe handle other server types ?
+        return false;
     }
 
     /**

--- a/index.php
+++ b/index.php
@@ -5,6 +5,9 @@ define('RASPMONITOR_VERSION', '0.2');
 /* Projet sous la licence WTFPL */
 
 require('classes/RaspStats.php');
+
+// Récupérer la version du serveur web
+$webserver_version = RaspStats::getWebserverVersion();
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -85,9 +88,16 @@ require('classes/RaspStats.php');
             <p>Version de PHP :
               <?= RaspStats::getPHPVersion() ?>
             </p>
-            <p>Version d'Apache :
-              <?= RaspStats::getApacheVersion() ?>
-            </p>
+
+            <?php if(!$webserver_version): ?>
+              <p>Impossible de trouver la version du serveur</p>
+            <?php else: ?>
+              <p>Version <?= $webserver_version['server'] ? 'de' : 'du serveur HTTP' ?> :
+                <?= $webserver_version['version'] ?>
+              </p>
+            <?php endif; ?>
+
+            
             <p>Information sur l'OS :
               <?= RaspStats::getOSInformation() ?>
             </p>


### PR DESCRIPTION
Returning an array instead of a plain old string.

I've also seen that `apache_get_version` doesn't always exist and its existance is checked before calling it.

Finally, I use `$_SERVER['SERVER_SOFTWARE']` to grab the HTTP server version before proceeding with anything else.